### PR TITLE
Feature/classe choix

### DIFF
--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/ChoixCarteAllies.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/ChoixCarteAllies.java
@@ -1,0 +1,24 @@
+package fr.utt.girardguittard.levasseur.menhir.joueurs;
+
+import fr.utt.girardguittard.levasseur.menhir.cartes.CarteAllies;
+
+public class ChoixCarteAllies {
+
+	private final CarteAllies carteChoisie;
+	
+	private final int cible;
+
+	public ChoixCarteAllies(CarteAllies carteChoisie, int cible) {
+		this.carteChoisie = carteChoisie;
+		this.cible = cible;
+	}
+
+	public CarteAllies getCarteChoisie() {
+		return carteChoisie;
+	}
+
+	public int getCible() {
+		return cible;
+	}
+	
+}

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/ChoixCarteIngredient.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/ChoixCarteIngredient.java
@@ -8,7 +8,7 @@ import fr.utt.girardguittard.levasseur.menhir.cartes.Action;
  * Cette carte sert de retour à la méthode deciderChoixDuTour
  *
  */
-public class ChoixJoueur {
+public class ChoixCarteIngredient {
 	
 	/**
 	 * La carte ingrédient choisie par le joueur
@@ -31,7 +31,7 @@ public class ChoixJoueur {
 	 * @param cible le joueur ciblé
 	 * @param actionChoisie l'action choisie par le joueur
 	 */
-	public ChoixJoueur(CarteIngredient carteChoisie, int cible, Action actionChoisie) {
+	public ChoixCarteIngredient(CarteIngredient carteChoisie, int cible, Action actionChoisie) {
 		this.carteChoisie = carteChoisie;
 		this.cible = cible;
 		this.actionChoisie = actionChoisie;

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/Joueur.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/Joueur.java
@@ -38,7 +38,7 @@ public abstract class Joueur {
 	 * @param tour le tour en cours
 	 */
 	public void jouerTour(Manche manche, Saison tour) {
-		ChoixJoueur choix = deciderChoixDuTour(manche, tour);
+		ChoixCarteIngredient choix = deciderChoixDuTour(manche, tour);
 		choix.getCarteChoisie().agir(manche, this.main, choix.getCible(), tour, choix.getActionChoisie());
 	}
 	
@@ -64,7 +64,7 @@ public abstract class Joueur {
 	 * @param manche la manche en cours
 	 * @param tour le tour en cours
 	 */
-	protected abstract ChoixJoueur deciderChoixDuTour(Manche manche, Saison tour);
+	protected abstract ChoixCarteIngredient deciderChoixDuTour(Manche manche, Saison tour);
 	
 	/**
 	 * Permet de choisir une carte allié

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/Joueur.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/Joueur.java
@@ -72,7 +72,7 @@ public abstract class Joueur {
 	 * @param tour le tour en cours
 	 * @param joueurActuel le numéro du joueur
 	 */
-	//protected abstract CarteAllies deciderCarteAllies(Manche manche, Saison tour, int joueurActuel);
+	protected abstract ChoixCarteAllies deciderCarteAllies(Manche manche, Saison tour, int joueurActuel);
 	
 	public int getScore() {
 		return this.scoreTotal;

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/JoueurPhysique.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/JoueurPhysique.java
@@ -27,7 +27,7 @@ public class JoueurPhysique extends Joueur {
 	 * @param tour le tour en cours
 	 * @param joueurActuel le numéro du joueur
 	 */
-	//protected CarteAllies deciderCarteAllies(Manche manche, Saison tour, int joueurActuel){
-	
-	//}
+	protected ChoixCarteAllies deciderCarteAllies(Manche manche, Saison tour, int joueurActuel) {
+		return null;
+	}
 }

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/JoueurPhysique.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/JoueurPhysique.java
@@ -17,8 +17,8 @@ public class JoueurPhysique extends Joueur {
 	 * @param manche la manche en cours
 	 * @param tour le tour en cours
 	 */
-	protected ChoixJoueur deciderChoixDuTour(Manche manche, Saison tour){
-		return new ChoixJoueur(null, 0, null);
+	protected ChoixCarteIngredient deciderChoixDuTour(Manche manche, Saison tour){
+		return new ChoixCarteIngredient(null, 0, null);
 	}
 	
 	/**

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/JoueurVirtuel.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/JoueurVirtuel.java
@@ -18,8 +18,8 @@ public class JoueurVirtuel extends Joueur{
 	 * @param manche la manche en cours
 	 * @param tour le tour en cours
 	 */
-	protected ChoixJoueur deciderChoixDuTour(Manche manche, Saison tour){
-		return new ChoixJoueur(null, 0, null);
+	protected ChoixCarteIngredient deciderChoixDuTour(Manche manche, Saison tour){
+		return new ChoixCarteIngredient(null, 0, null);
 	}
 	
 	/**

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/JoueurVirtuel.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/JoueurVirtuel.java
@@ -28,7 +28,7 @@ public class JoueurVirtuel extends Joueur{
 	 * @param tour le tour en cours
 	 * @param joueurActuel le numéro du joueur
 	 */
-	//protected CarteAllies deciderCarteAllies(Manche manche, Saison tour, int joueurActuel){
-	
-	//}
+	protected ChoixCarteAllies deciderCarteAllies(Manche manche, Saison tour, int joueurActuel) {
+		return null;
+	}
 }

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/strategie/Strategie.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/strategie/Strategie.java
@@ -4,7 +4,8 @@ import fr.utt.girardguittard.levasseur.menhir.Manche;
 import fr.utt.girardguittard.levasseur.menhir.Saison;
 import fr.utt.girardguittard.levasseur.menhir.cartes.Action;
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteIngredient;
-import fr.utt.girardguittard.levasseur.menhir.joueurs.ChoixJoueur;
+import fr.utt.girardguittard.levasseur.menhir.joueurs.ChoixCarteAllies;
+import fr.utt.girardguittard.levasseur.menhir.joueurs.ChoixCarteIngredient;
 
 /**
  * Permet aux joueurs virtuels de décider des actions à réaliser
@@ -18,7 +19,7 @@ public interface Strategie {
 	 * @param carteChoisie la carte tirée (out)
 	 * @param actionChoisie l'action choisie par le joueur (out)
 	 */
-	public ChoixJoueur deciderChoixDuTour(Manche manche, Saison tour);
+	public ChoixCarteIngredient deciderChoixDuTour(Manche manche, Saison tour);
 	
 	/**
 	 * Permet de choisir une carte allié
@@ -26,6 +27,6 @@ public interface Strategie {
 	 * @param tour le tour en cours
 	 * @param joueurActuel le numéro du joueur
 	 */
-	//public CarteAllies deciderCarteAllies(Manche manche, Saison tour, int joueurActuel); 
+	public ChoixCarteAllies deciderCarteAllies(Manche manche, Saison tour, int joueurActuel); 
 
 }


### PR DESCRIPTION
Ajoute la classe `ChoixCarteAllies` retourner par les méthodes qui choisissent la carte alliés à jouer. Renomme `ChoixJoueur` en `ChoixCarteIngredient`.
