### PR TITLE
Décomposition des méthodes jouer() de Partie et Manche en plusieurs méthodes

### DIFF
--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/ActionIllegaleException.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/ActionIllegaleException.java
@@ -1,0 +1,36 @@
+package fr.utt.girardguittard.levasseur.menhir;
+
+public class ActionIllegaleException extends Exception {
+
+	public ActionIllegaleException() {
+		super();
+		// TODO Stub du constructeur généré automatiquement
+	}
+
+	public ActionIllegaleException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+		// TODO Stub du constructeur généré automatiquement
+	}
+
+	public ActionIllegaleException(String message, Throwable cause) {
+		super(message, cause);
+		// TODO Stub du constructeur généré automatiquement
+	}
+
+	public ActionIllegaleException(String message) {
+		super(message);
+		// TODO Stub du constructeur généré automatiquement
+	}
+
+	public ActionIllegaleException(Throwable cause) {
+		super(cause);
+		// TODO Stub du constructeur généré automatiquement
+	}
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 3493239688882631351L;
+
+}

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/EtatManche.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/EtatManche.java
@@ -1,0 +1,12 @@
+package fr.utt.girardguittard.levasseur.menhir;
+
+public enum EtatManche {
+	DEBUT_MANCHE,
+	EN_ATTENTE_CHOIX_CARTE_ALLIES,
+	PRET_A_DEMARRER,
+	DEBUT_SAISON,
+	DEBUT_TOUR_JOUEUR,
+	FIN_TOUR_JOUEUR,
+	FIN_SAISON,
+	FIN_MANCHE
+}

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/EtatPartie.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/EtatPartie.java
@@ -1,0 +1,8 @@
+package fr.utt.girardguittard.levasseur.menhir;
+
+public enum EtatPartie {
+	LANCEE,
+	MANCHE_EN_COURS,
+	MANCHE_FINIE,
+	FINIE
+}

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Manche.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Manche.java
@@ -8,6 +8,7 @@ import java.util.Observable;
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteAllies;
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteIngredient;
 import fr.utt.girardguittard.levasseur.menhir.cartes.DeckCartes;
+import fr.utt.girardguittard.levasseur.menhir.joueurs.CarteInvalideException;
 import fr.utt.girardguittard.levasseur.menhir.joueurs.Joueur;
 import fr.utt.girardguittard.levasseur.menhir.joueurs.MainJoueur;
 import fr.utt.girardguittard.levasseur.menhir.ui.InterfaceManager;
@@ -191,7 +192,7 @@ public class Manche extends Observable {
 		this.notifyObservers();
 	}
 	
-	public void jouerTourJoueur() throws ActionIllegaleException {
+	public void jouerTourJoueur() throws ActionIllegaleException, CarteInvalideException {
 		if(this.etat != EtatManche.DEBUT_TOUR_JOUEUR) {
 			throw new ActionIllegaleException("jouerTourJoueur() doit être appelée après demarrerTour() !");
 		}

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Manche.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Manche.java
@@ -224,6 +224,10 @@ public class Manche extends Observable {
 	}
 	
 	public void finManche() throws ActionIllegaleException {
+		if(this.etat != EtatManche.FIN_SAISON && this.saisonActuelle != Saison.HIVER) {
+			throw new ActionIllegaleException("finManche() doit être appelée à la fin de la saison HIVER !");
+		}
+		
 		//On ajoute les menhirs de la manche au score des joueurs
 		for(Iterator<MainJoueur> itMainJoueur = this.mainsDesJoueurs.iterator(); itMainJoueur.hasNext(); ) {
 			MainJoueur mainJoueur = itMainJoueur.next();

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Manche.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Manche.java
@@ -3,6 +3,7 @@ package fr.utt.girardguittard.levasseur.menhir;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Observable;
 
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteAllies;
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteIngredient;
@@ -16,7 +17,7 @@ import fr.utt.girardguittard.levasseur.menhir.util.ScoreMancheComparator;
 /**
  * La classe Manche représente une manche et permet de faire son déroulement.
  */
-public class Manche {
+public class Manche extends Observable {
 	
 	/**
 	 * Saison actuelle.
@@ -58,6 +59,10 @@ public class Manche {
 	 */
 	private DeckCartes<CarteAllies> deckAllies;
 	
+	private EtatManche etat;
+	
+	
+	
 	/**
 	 * Constructeur de Manche.
 	 * @param partieAvancee booléen valant vrai si la partie est avancée
@@ -70,6 +75,8 @@ public class Manche {
 			DeckCartes<CarteIngredient> deckIngredient,
 			DeckCartes<CarteAllies> deckAllies,
 			int premierJoueur) {
+		super();
+		
 		this.saisonActuelle = Saison.PRINTEMPS;
 		this.joueurTour = 0;
 		this.premierJoueur = premierJoueur;
@@ -91,18 +98,30 @@ public class Manche {
 		if(deckAllies != null) {
 			deckAllies.remettreCartesEtMelanger();
 		}
+		
+		this.etat = EtatManche.DEBUT_MANCHE;
 	}
 	
-	/**
-	 * Joue la manche.
-	 */
-	public void jouer() {
+	public void distribuerCartesIngredients() throws ActionIllegaleException {
+		if(this.etat != EtatManche.DEBUT_MANCHE) {
+			throw new ActionIllegaleException("Ne peut pas distribuer les cartes ingrédients après le début de la partie !");
+		}
 		
 		//Distribution des cartes ingrédients
 		for(int i = 0; i < 4; i++) {
 			for(Iterator<MainJoueur> it = this.mainsDesJoueurs.iterator(); it.hasNext(); ) {
 				it.next().ajouterCarteIngredient(deckIngredient.getCarte());
 			}
+		}
+		
+		this.etat = EtatManche.EN_ATTENTE_CHOIX_CARTE_ALLIES;
+		
+		this.notifyObservers();
+	}
+	
+	public void distribuerCartesAllies() throws ActionIllegaleException {
+		if(this.etat != EtatManche.EN_ATTENTE_CHOIX_CARTE_ALLIES) {
+			throw new ActionIllegaleException("distributerCartesAllies() doit être appelée après la distribution des cartes ingrédients !");
 		}
 		
 		//Distribution des cartes alliés (si en partie avancée et si le joueur en veut une)
@@ -124,41 +143,104 @@ public class Manche {
 			}
 		}
 		
-		//On fait le déroulement des 4 saisons
-		for(Saison saison : Saison.values()) {
-			this.saisonActuelle = saison;
-			InterfaceManager.get().notifierDebutSaison(this.saisonActuelle);
-			
-			//On fait jouer chaque joueur, en commençant par le joueur qui doit jouer en premier (this.premierJoueur).
-			//(on n'utilise pas Iterator car on a besoin de l'index de l'itération)
-			for(int i = 0; i < this.mainsDesJoueurs.size(); i++) {
-				//Le numéro du joueur qui doit jouer : 
-				int numJoueur = (i + this.premierJoueur) % this.mainsDesJoueurs.size(); 
-				InterfaceManager.get().notifierDebutTour(numJoueur);
-				
-				//On propose à tous les joueurs de jouer une carte alliés s'ils le veulent
-				//(car il est possible de jouer des cartes alliés à tout moment)
-				//(uniquement pour les parties avancées)
-				if(this.partieAvancee) {
-					for(Iterator<MainJoueur> itMainJoueur = this.mainsDesJoueurs.iterator(); itMainJoueur.hasNext(); ) {
-						itMainJoueur.next().getJoueur().jouerCartesAllies(this, saison, numJoueur);
-					}
-				}
-				
-				//On fait jouer le joueur
-				this.getJoueur(numJoueur).jouerTour(this, saison);
-				
-				InterfaceManager.get().notifierFinTour();
-			}
-			
-			InterfaceManager.get().notifierFinSaison();
+		this.etat = EtatManche.PRET_A_DEMARRER;
+		
+		this.notifyObservers();
+	}
+	
+	public void demarrerSaison() throws ActionIllegaleException {
+		if(this.etat != EtatManche.PRET_A_DEMARRER && this.etat != EtatManche.FIN_SAISON) {
+			throw new ActionIllegaleException("demarrerSaison() doit être appelée après la distribution des cartes ou à la fin d'une saison précédente");
 		}
-
+		
+		//On incrémente la saison (à moins que ce soit le 1er appel de cette méthode)
+		if(this.etat == EtatManche.FIN_SAISON) {
+			this.saisonActuelle = Saison.PRINTEMPS;
+			this.joueurTour = this.premierJoueur;
+		} else {
+			this.saisonActuelle = Saison.values()[this.saisonActuelle.ordinal() + 1];
+			this.joueurTour = this.premierJoueur;
+		}
+		
+		this.etat = EtatManche.DEBUT_SAISON;
+		
+		this.notifyObservers();
+	}
+	
+	public void demarrerTour() throws ActionIllegaleException {
+		if(this.etat != EtatManche.DEBUT_SAISON && this.etat != EtatManche.FIN_TOUR_JOUEUR) {
+			throw new ActionIllegaleException("demarrerTour() doit être appelée au début d'une saison ou à la fin du tour précédent !");
+		}
+		
+		if(this.etat == EtatManche.DEBUT_SAISON) {
+			this.joueurTour = this.premierJoueur; //C'est le premier tour d'une saison, le premier joueur doit jouer
+		} else {
+			//Incrémentation du numéro du joueur qui joue
+			this.joueurTour = (this.joueurTour + 1) % this.mainsDesJoueurs.size();
+			
+			if(this.joueurTour == this.premierJoueur) { //Si après incrémentation, on retombe sur le premier joueur
+				//Cela signifie que l'on a fini la saison
+				this.etat = EtatManche.FIN_SAISON;
+				this.notifyObservers();
+				return;
+			}
+		}
+		
+		this.etat = EtatManche.DEBUT_TOUR_JOUEUR;
+		
+		this.notifyObservers();
+	}
+	
+	public void jouerTourJoueur() throws ActionIllegaleException {
+		if(this.etat != EtatManche.DEBUT_TOUR_JOUEUR) {
+			throw new ActionIllegaleException("jouerTourJoueur() doit être appelée après demarrerTour() !");
+		}
+		
+		//On fait jouer le joueur
+		this.getJoueur(this.joueurTour).jouerTour(this, this.saisonActuelle);
+		
+		this.etat = EtatManche.FIN_TOUR_JOUEUR;
+		
+		this.notifyObservers();
+	}
+	
+	public void jouerCartesAllies() throws ActionIllegaleException {
+		if(this.etat != EtatManche.DEBUT_SAISON && this.etat != EtatManche.DEBUT_TOUR_JOUEUR &&
+		   this.etat != EtatManche.FIN_TOUR_JOUEUR) {
+			throw new ActionIllegaleException("jouerCartesAllies() doit être appelée pendant le tour des joueurs !");
+		}
+		if(!this.partieAvancee) {
+			throw new ActionIllegaleException("jouerCartesAllies() ne peut pas être utilisée dans une partie simple !");
+		}
+		
+		//On propose à tous les joueurs de jouer une carte alliés s'ils le veulent
+		//(car il est possible de jouer des cartes alliés à tout moment)
+		//(uniquement pour les parties avancées)
+		for(Iterator<MainJoueur> itMainJoueur = this.mainsDesJoueurs.iterator(); itMainJoueur.hasNext(); ) {
+			itMainJoueur.next().getJoueur().jouerCartesAllies(this, this.saisonActuelle, this.joueurTour);
+		}
+		
+		this.notifyObservers();
+	}
+	
+	public void finManche() throws ActionIllegaleException {
 		//On ajoute les menhirs de la manche au score des joueurs
 		for(Iterator<MainJoueur> itMainJoueur = this.mainsDesJoueurs.iterator(); itMainJoueur.hasNext(); ) {
 			MainJoueur mainJoueur = itMainJoueur.next();
 			mainJoueur.getJoueur().incrementerScore(mainJoueur.getNombreMenhir());
 		}
+		
+		//On signale que la manche est finie
+		this.etat = EtatManche.FIN_MANCHE;
+		
+		this.notifyObservers();
+	}
+	
+	/**
+	 * Joue la manche.
+	 */
+	public void jouer() {
+		
 	}
 	
 	/**
@@ -186,6 +268,18 @@ public class Manche {
 		return this.nombreJoueurs;
 	}
 	
+	public Saison getSaisonActuelle() {
+		return saisonActuelle;
+	}
+
+	public int getJoueurTour() {
+		return joueurTour;
+	}
+
+	public EtatManche getEtat() {
+		return etat;
+	}
+
 	/**
 	 * Calcule le classement des joueurs dans la manche (en ne prenant en compte que cette manche)
 	 * @return un tableau de Joueur ordonné du joueur le mieux classé au moins bien classé dans la manche

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Partie.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Partie.java
@@ -79,6 +79,11 @@ public class Partie extends Observable implements Observer {
 		}
 		
 		this.numeroMancheEnCours++;
+		if(this.numeroMancheEnCours >= (this.partieAvancee ? this.joueurs.size() : 1)) {
+			this.etat = EtatPartie.FINIE;
+			this.notifyObservers();
+			return;
+		}
 		
 		//Création de la manche
 		this.mancheEnCours = new Manche(this.partieAvancee, 
@@ -147,7 +152,7 @@ public class Partie extends Observable implements Observer {
 	
 	/**
 	 * Calcule le classement des joueurs dans la manche.
-	 * @return un tableau de Joueur ordonné du joueur le mieux classé au moins bien classé dans la manche
+	 * @return un tableau de Joueur ordonné du joueur le mieux classé au moins bien classé dans la partie
 	 */
 	public ArrayList<Joueur> calculerClassementPartie() {
 		ArrayList<Joueur> joueursClasses = new ArrayList<Joueur>(this.joueurs);

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Partie.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Partie.java
@@ -3,6 +3,8 @@ package fr.utt.girardguittard.levasseur.menhir;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Observable;
+import java.util.Observer;
 import java.util.Random;
 
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteAllies;
@@ -18,7 +20,7 @@ import fr.utt.girardguittard.levasseur.menhir.util.Console;
 import fr.utt.girardguittard.levasseur.menhir.util.ScoreMancheComparator;
 import fr.utt.girardguittard.levasseur.menhir.util.ScorePartieComparator;
 
-public class Partie {
+public class Partie extends Observable implements Observer {
 	
 	final private boolean partieAvancee;
 
@@ -28,7 +30,17 @@ public class Partie {
 	
 	private DeckCartes<CarteAllies> deckCartesAllies;
 	
+	private int premierJoueur;
+	
+	private EtatPartie etat;
+	
+	private int numeroMancheEnCours;
+	
+	private Manche mancheEnCours;
+	
 	public Partie(int nombreJoueurs, boolean partieAvancee) {
+		super();
+		
 		this.partieAvancee = partieAvancee;
 		this.joueurs = new ArrayList<Joueur>();
 		
@@ -49,14 +61,42 @@ public class Partie {
 		} else {
 			this.deckCartesAllies = null;
 		}
-	}
-
-	void jouer() {
-		//On notifie l'interface utilisateur que la partie est lancée
-		InterfaceManager.get().notifierDebutPartie(this);
 		
 		//On choisit aléatoirement le premier joueur qui va débuter la première manche
-		int premierJoueur = (int)(Math.random() * (float)this.joueurs.size());
+		this.premierJoueur = (int)(Math.random() * (float)this.joueurs.size());
+		
+		//On dit que la partie est lancée
+		this.etat = EtatPartie.LANCEE;
+		
+		//La manche qui sera lancée sera la première manche
+		this.numeroMancheEnCours = -1;
+		this.mancheEnCours = null;
+	}
+
+	public void demarrerManche() throws ActionIllegaleException {
+		if(this.etat == EtatPartie.FINIE || this.etat == EtatPartie.MANCHE_EN_COURS) {
+			throw new ActionIllegaleException("Ne peut pas appeler demarrerManche() lorsque la partie est finie ou lorsqu'une manche est en cours");
+		}
+		
+		this.numeroMancheEnCours++;
+		
+		//Création de la manche
+		this.mancheEnCours = new Manche(this.partieAvancee, 
+			this.joueurs, 
+			this.deckCartesIngredient, 
+			this.deckCartesAllies,
+			(premierJoueur + this.numeroMancheEnCours) % this.joueurs.size()
+			);
+		this.mancheEnCours.addObserver(this);
+		
+		this.etat = EtatPartie.MANCHE_EN_COURS;
+		
+		this.notifyObservers();
+	}
+
+	public void jouer() {
+		//On notifie l'interface utilisateur que la partie est lancée
+		InterfaceManager.get().notifierDebutPartie(this);
 		
 		//On effectue le nombre de manches souhaités (1 si partie simple, le nombre de manches sinon)
 		//La condition ternaire est plutôt utile ici...
@@ -93,6 +133,18 @@ public class Partie {
 		return joueurs;
 	}
 	
+	public EtatPartie getEtat() {
+		return etat;
+	}
+
+	public int getNumeroMancheEnCours() {
+		return numeroMancheEnCours;
+	}
+
+	public Manche getMancheEnCours() {
+		return mancheEnCours;
+	}
+	
 	/**
 	 * Calcule le classement des joueurs dans la manche.
 	 * @return un tableau de Joueur ordonné du joueur le mieux classé au moins bien classé dans la manche
@@ -124,5 +176,21 @@ public class Partie {
 		}
 		
 		return vainqueurs;
+	}
+
+	/**
+	 * Méthode update du design pattern observer/observable.
+	 * La classe Partie observe la Manche en cours pour savoir quand elle se termine
+	 */
+	public void update(Observable arg0, Object arg1) {
+		// On regarde si arg0 est une Manche et voir si elle est terminée
+		//         ==> si c'est le cas, mettre etat à EtatPartie.MANCHE_FINIE
+		if(arg0 instanceof Manche) {
+			Manche manche = (Manche) arg0;
+			if(manche.getEtat() == EtatManche.FIN_MANCHE) {
+				this.etat = EtatPartie.MANCHE_FINIE;
+				this.notifyObservers();
+			}
+		}
 	}
 }

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/CarteInvalideException.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/CarteInvalideException.java
@@ -1,0 +1,30 @@
+package fr.utt.girardguittard.levasseur.menhir.joueurs;
+
+public class CarteInvalideException extends Exception {
+
+	public CarteInvalideException() {
+		// TODO Stub du constructeur généré automatiquement
+	}
+
+	public CarteInvalideException(String message) {
+		super(message);
+		// TODO Stub du constructeur généré automatiquement
+	}
+
+	public CarteInvalideException(Throwable cause) {
+		super(cause);
+		// TODO Stub du constructeur généré automatiquement
+	}
+
+	public CarteInvalideException(String message, Throwable cause) {
+		super(message, cause);
+		// TODO Stub du constructeur généré automatiquement
+	}
+
+	public CarteInvalideException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+		// TODO Stub du constructeur généré automatiquement
+	}
+
+}

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/Joueur.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/Joueur.java
@@ -44,9 +44,16 @@ public abstract class Joueur {
 	 * Il s'agit de décider qu'elle action réaliser et de l'effectuer.
 	 * @param manche la manche en cours
 	 * @param tour le tour en cours
+	 * @throws CarteInvalideException 
 	 */
-	public void jouerTour(Manche manche, Saison tour) {
+	public void jouerTour(Manche manche, Saison tour) throws CarteInvalideException {
 		ChoixCarteIngredient choix = deciderChoixDuTour(manche, tour);
+		
+		//On vérifie bien que la carte est dans la main du joueur
+		if(!this.main.contientCarteIngredient(choix.getCarteChoisie())) {
+			throw new CarteInvalideException("La carte choisie est invalide (aucune ou pas dans la main du joueur) !");
+		}
+		
 		int forceReelle = choix.getCarteChoisie().agir(manche, this.main, choix.getCible(), tour, choix.getActionChoisie());
 		this.getMain().retirerCarteIngredient(choix.getCarteChoisie());
 		

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/JoueurPhysique.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/JoueurPhysique.java
@@ -12,6 +12,12 @@ import fr.utt.girardguittard.levasseur.menhir.cartes.CarteAllies;
  *
  */
 public class JoueurPhysique extends Joueur {
+	
+	boolean veutPrendreCarteAllies;
+	
+	ChoixCarteIngredient prochainChoixIngredient;
+	
+	ChoixCarteAllies prochainChoixAllies;
 
 	/**
 	 * Construit un joueur physique.
@@ -19,6 +25,9 @@ public class JoueurPhysique extends Joueur {
 	 */
 	public JoueurPhysique(int numero) {
 		super(numero);
+		this.veutPrendreCarteAllies = false;
+		this.prochainChoixIngredient = null;
+		this.prochainChoixAllies = new ChoixCarteAllies(false, -1);
 	}
 
 	/**
@@ -27,7 +36,7 @@ public class JoueurPhysique extends Joueur {
 	 * @param tour le tour en cours
 	 */
 	protected ChoixCarteIngredient deciderChoixDuTour(Manche manche, Saison tour){
-		return InterfaceManager.get().demanderCarteIngredientAJouer(getMain());
+		return this.prochainChoixIngredient;
 	}
 	
 	/**
@@ -37,10 +46,10 @@ public class JoueurPhysique extends Joueur {
 	 * @param joueurActuel le numéro du joueur
 	 */
 	protected ChoixCarteAllies deciderCarteAllies(Manche manche, Saison tour, int joueurActuel) {
-		return InterfaceManager.get().demanderCarteAllies(this.getMain());
+		return this.prochainChoixAllies;
 	}
 	
 	public boolean veutCarteAllies() {
-		return InterfaceManager.get().demanderCarteOuGraines();
+		return this.veutPrendreCarteAllies;
 	}
 }

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/MainJoueur.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/MainJoueur.java
@@ -199,6 +199,15 @@ public class MainJoueur {
 			return null;
 		}
 	}
+	
+	/**
+	 * Détermine si la carte est bien dans la main du joueur.
+	 * @param carte la carte à tester
+	 * @return vrai ou faux suivant si la carte est bien dans la main
+	 */
+	public boolean contientCarteIngredient(CarteIngredient carte) {
+		return this.cartesIngredient.contains(carte);
+	}
 
 	/**
 	 * Récupère la carte alliés du joueur (s'il en a une)

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/MainJoueur.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/MainJoueur.java
@@ -1,11 +1,13 @@
 package fr.utt.girardguittard.levasseur.menhir.joueurs;
 
 import java.util.ArrayList;
+import java.util.Observable;
+
 import fr.utt.girardguittard.levasseur.menhir.Manche;
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteAllies;
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteIngredient;
 
-public class MainJoueur {
+public class MainJoueur extends Observable {
 
 	/**
 	 * Le joueur auquel appartient la main.
@@ -48,6 +50,8 @@ public class MainJoueur {
 	 * @param manche la manche jouée par le joueur avec cette main
 	 */
 	public MainJoueur(Joueur joueur, Manche manche) {
+		super();
+		
 		//Initialisation de l'association
 		this.joueur = joueur;
 		this.manche = manche;
@@ -80,6 +84,8 @@ public class MainJoueur {
 	 */
 	public void ajouterGraines(int graines) {
 		this.nombreGraine += graines;
+		
+		this.notifyObservers();
 	}
 	
 	/**
@@ -96,6 +102,8 @@ public class MainJoueur {
 			grainesVolees--;
 		}
 		this.nombreGraine -= grainesVolees;
+		
+		this.notifyObservers();
 		
 		return grainesVolees;
 	}
@@ -120,6 +128,8 @@ public class MainJoueur {
 		this.defenseChienDeGarde = Math.max(0, this.defenseChienDeGarde - menhirsPousses); //On réduit la défense du nombre
 		this.nombreMenhir += menhirsPousses;
 		
+		this.notifyObservers();
+		
 		return menhirsPousses;
 	}
 	
@@ -131,6 +141,8 @@ public class MainJoueur {
 	public int detruireMenhir(int menhirs) {
 		int menhirsDetruits = Math.min(this.nombreMenhir, menhirs);
 		this.nombreMenhir -= menhirsDetruits;
+		
+		this.notifyObservers();
 		
 		return menhirsDetruits;
 	}
@@ -148,6 +160,8 @@ public class MainJoueur {
 
 	public void setDefenseChienDeGarde(int defenseChienDeGarde) {
 		this.defenseChienDeGarde = Math.min(defenseChienDeGarde, this.nombreGraine);
+		
+		this.notifyObservers();
 	}
 
 	/**
@@ -157,6 +171,8 @@ public class MainJoueur {
 	public void ajouterCarteIngredient(CarteIngredient carteIngredient) {
 		if(this.cartesIngredient.size() <= 3) {
 			this.cartesIngredient.add(carteIngredient);
+			
+			this.notifyObservers();
 		}
 	}
 	
@@ -167,6 +183,8 @@ public class MainJoueur {
 	public void retirerCarteIngredient(int carte) {
 		if(carte < this.cartesIngredient.size()) {
 			this.cartesIngredient.remove(carte);
+			
+			this.notifyObservers();
 		}
 	}
 	
@@ -177,6 +195,8 @@ public class MainJoueur {
 	 */
 	public void retirerCarteIngredient(CarteIngredient carte) {
 		this.cartesIngredient.remove(carte);
+		
+		this.notifyObservers();
 	}
 	
 	/**
@@ -223,6 +243,8 @@ public class MainJoueur {
 	 */
 	public void setCarteAllies(CarteAllies carteAllies) {
 		this.carteAllies = carteAllies;
+		
+		this.notifyObservers();
 	}
 	
 	/**
@@ -230,5 +252,7 @@ public class MainJoueur {
 	 */
 	public void retirerCarteAllies() {
 		this.setCarteAllies(null);
+		
+		this.notifyObservers();
 	}
 }


### PR DESCRIPTION
**Les méthodes `jouer()` de `Partie` et `Manche` découpées en plusieurs petites méthodes avec stockage de l'état de la `Partie`/`Manche` dans des attributs.**

Une enum pour `Partie` et une autre pour `Manche` permettent de représenter l'état de la `Partie`/`Manche`. Les deux classes ainsi que `MainJoueur` sont maintenant observable et envoient des notifications à chaque changement d'état. Des exceptions permettent aussi d'empêcher l'appel de méthodes de changement d'état à de mauvais moment (_on ne peut pas lancer une nouvelle manche alors que la précédente n'est pas finie par exemple_).

Le jeu en console ne fonctionne plus du coup. Il faudra que je le recode sous forme d'un controlleur/vue mixé pour qu'il remarche. Il y a d'ailleurs peu de chance de pouvoir utiliser le jeu sous forme de console et de GUI en même temps car les 2 vues sont trop incompatibles dans leur façon de fonctionner (l'une bloquante et l'autre non bloquante...).
