### PR TITLE
Passage des cartes jouées et de leur force réelle aux observers de Manche.

### DIFF
--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Manche.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/Manche.java
@@ -8,6 +8,8 @@ import java.util.Observable;
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteAllies;
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteIngredient;
 import fr.utt.girardguittard.levasseur.menhir.cartes.DeckCartes;
+import fr.utt.girardguittard.levasseur.menhir.cartes.InfoCarteAlliesJouee;
+import fr.utt.girardguittard.levasseur.menhir.cartes.InfoCarteIngredientJouee;
 import fr.utt.girardguittard.levasseur.menhir.joueurs.CarteInvalideException;
 import fr.utt.girardguittard.levasseur.menhir.joueurs.Joueur;
 import fr.utt.girardguittard.levasseur.menhir.joueurs.MainJoueur;
@@ -207,12 +209,12 @@ public class Manche extends Observable {
 		}
 		
 		//On fait jouer le joueur
-		this.getJoueur(this.joueurTour).jouerTour(this, this.saisonActuelle);
+		InfoCarteIngredientJouee info = this.getJoueur(this.joueurTour).jouerTour(this, this.saisonActuelle);
 		
 		this.etat = EtatManche.FIN_TOUR_JOUEUR;
 		
 		this.setChanged();
-		this.notifyObservers();
+		this.notifyObservers(info);
 	}
 	
 	public void jouerCartesAllies() throws ActionIllegaleException {
@@ -227,12 +229,14 @@ public class Manche extends Observable {
 		//On propose à tous les joueurs de jouer une carte alliés s'ils le veulent
 		//(car il est possible de jouer des cartes alliés à tout moment)
 		//(uniquement pour les parties avancées)
+		ArrayList<InfoCarteAlliesJouee> infos = new ArrayList<InfoCarteAlliesJouee>();
 		for(Iterator<MainJoueur> itMainJoueur = this.mainsDesJoueurs.iterator(); itMainJoueur.hasNext(); ) {
-			itMainJoueur.next().getJoueur().jouerCartesAllies(this, this.saisonActuelle, this.joueurTour);
+			InfoCarteAlliesJouee info = itMainJoueur.next().getJoueur().jouerCartesAllies(this, this.saisonActuelle, this.joueurTour);
+			infos.add(info);
 		}
 		
 		this.setChanged();
-		this.notifyObservers();
+		this.notifyObservers(infos);
 	}
 	
 	private void finManche() throws ActionIllegaleException {

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/cartes/InfoCarteAlliesJouee.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/cartes/InfoCarteAlliesJouee.java
@@ -1,0 +1,63 @@
+package fr.utt.girardguittard.levasseur.menhir.cartes;
+
+import fr.utt.girardguittard.levasseur.menhir.Saison;
+import fr.utt.girardguittard.levasseur.menhir.joueurs.ChoixCarteAllies;
+
+/**
+ * Classe permettant de transporter les données à notifier aux vues à
+ * propos d'une carte alliés qui a été jouée. Elle permet, entre autre,
+ * de connaître la force effective/réelle de la carte lorsqu'elle a été jouée
+ * (exemple : le nombre de menhirs vraiment détruit chez un adversaire).
+ */
+public class InfoCarteAlliesJouee {
+
+	private final int numeroJoueur;
+	
+	private final Saison saison;
+	
+	private final CarteAllies carteJouee;
+	
+	private final int joueurCible;
+	
+	private final int forceTheorique;
+	
+	private final int forceReelle;
+	
+	public InfoCarteAlliesJouee(int numeroJoueur, Saison saison, ChoixCarteAllies choix, CarteAllies carteAllies, int forceReelle) {
+		this.numeroJoueur = numeroJoueur;
+		this.saison = saison;
+		this.carteJouee = choix.isJoue() ? carteAllies : null;
+		this.joueurCible = choix.getCible();
+		this.forceTheorique = carteAllies != null ? carteAllies.getForce(saison) : 0;
+		this.forceReelle = forceReelle;
+	}
+
+	public int getNumeroJoueur() {
+		return numeroJoueur;
+	}
+
+	public Saison getSaison() {
+		return saison;
+	}
+	
+	public boolean isJouee() {
+		return this.carteJouee != null;
+	}
+
+	public CarteAllies getCarteJouee() {
+		return carteJouee;
+	}
+
+	public int getJoueurCible() {
+		return joueurCible;
+	}
+
+	public int getForceTheorique() {
+		return forceTheorique;
+	}
+
+	public int getForceReelle() {
+		return forceReelle;
+	}
+	
+}

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/cartes/InfoCarteIngredientJouee.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/cartes/InfoCarteIngredientJouee.java
@@ -1,0 +1,66 @@
+package fr.utt.girardguittard.levasseur.menhir.cartes;
+
+import fr.utt.girardguittard.levasseur.menhir.Saison;
+import fr.utt.girardguittard.levasseur.menhir.joueurs.ChoixCarteIngredient;
+
+/**
+ * Classe permettant de transporter les données à notifier aux vues à
+ * propos d'une carte ingrédient qui a été jouée. Elle permet, entre autre,
+ * de connaître la force effective/réelle de la carte lorsqu'elle a été jouée
+ * (exemple : le nombre de graines vraiment volées à un autre joueur).
+ */
+public class InfoCarteIngredientJouee {
+	
+	private final int numeroJoueur;
+	
+	private final Saison saison;
+	
+	private final CarteIngredient carteJouee;
+	
+	private final Action actionJouee;
+	
+	private final int joueurCible;
+	
+	private final int forceTheorique;
+	
+	private final int forceReelle;
+	
+	public InfoCarteIngredientJouee(int numeroJoueur, Saison saison, ChoixCarteIngredient choix, int forceReelle) {
+		this.numeroJoueur = numeroJoueur;
+		this.saison = saison;
+		this.carteJouee = choix.getCarteChoisie();
+		this.actionJouee = choix.getActionChoisie();
+		this.joueurCible = choix.getCible();
+		this.forceTheorique = choix.getCarteChoisie().getForce(saison, choix.getActionChoisie());
+		this.forceReelle = forceReelle;
+	}
+
+	public int getNumeroJoueur() {
+		return numeroJoueur;
+	}
+
+	public Saison getSaison() {
+		return saison;
+	}
+
+	public CarteIngredient getCarteJouee() {
+		return carteJouee;
+	}
+
+	public Action getActionJouee() {
+		return actionJouee;
+	}
+
+	public int getJoueurCible() {
+		return joueurCible;
+	}
+
+	public int getForceTheorique() {
+		return forceTheorique;
+	}
+
+	public int getForceReelle() {
+		return forceReelle;
+	}
+	
+}

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/console/JeuConsole.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/console/JeuConsole.java
@@ -11,6 +11,11 @@ import fr.utt.girardguittard.levasseur.menhir.EtatPartie;
 import fr.utt.girardguittard.levasseur.menhir.Manche;
 import fr.utt.girardguittard.levasseur.menhir.Partie;
 import fr.utt.girardguittard.levasseur.menhir.cartes.Action;
+import fr.utt.girardguittard.levasseur.menhir.cartes.CarteAllies;
+import fr.utt.girardguittard.levasseur.menhir.cartes.ChiensDeGarde;
+import fr.utt.girardguittard.levasseur.menhir.cartes.InfoCarteAlliesJouee;
+import fr.utt.girardguittard.levasseur.menhir.cartes.InfoCarteIngredientJouee;
+import fr.utt.girardguittard.levasseur.menhir.cartes.TaupesGeantes;
 import fr.utt.girardguittard.levasseur.menhir.joueurs.CarteInvalideException;
 import fr.utt.girardguittard.levasseur.menhir.joueurs.ChoixCarteAllies;
 import fr.utt.girardguittard.levasseur.menhir.joueurs.ChoixCarteIngredient;
@@ -185,7 +190,27 @@ public class JeuConsole implements Observer {
 				} else if(this.mancheEnCours.getEtat() == EtatManche.FIN_TOUR_JOUEUR) {
 					//C'est la fin du tour d'un joueur
 					
+					//On affiche les notification des cartes qui ont été jouées (s'il y en a)
+					if(arg1 instanceof InfoCarteIngredientJouee) {
+						//On affiche le résultat de l'exécution de la carte ingrédient du joueur
+						InfoCarteIngredientJouee info = (InfoCarteIngredientJouee)arg1;
+						this.notifierAgissementCarte(info);
+					} else if(arg1 instanceof ArrayList<?>) { 
+						if(((ArrayList<?>)arg1).size() > 0 && ((ArrayList<?>)arg1).get(0) instanceof InfoCarteAlliesJouee) {
+							//On affiche le résultat des cartes allies si certaines ont été jouées
+							ArrayList<InfoCarteAlliesJouee> infos = (ArrayList<InfoCarteAlliesJouee>)arg1;
+							for(Iterator<InfoCarteAlliesJouee> it = infos.iterator(); it.hasNext(); ) {
+								InfoCarteAlliesJouee info = it.next();
+								if(info.isJouee()) {
+									//On affiche que le joueur a joué la carte alliés uniquement s'il l'a jouée !
+									this.notifierAgissementCarte(info);
+								}
+							}
+						}
+					}
+					
 					if(this.partie.isPartieAvancee() && !this.carteAlliesJouees) {
+						
 						this.carteAlliesJouees = true;
 						//Si les cartes alliés n'ont pas été encore jouées :
 						
@@ -364,6 +389,56 @@ public class JeuConsole implements Observer {
 		}
 		else {
 			joueur.setProchainChoixAllies(new ChoixCarteAllies(false, -1));
+		}
+	}
+	
+	private void notifierAgissementCarte(InfoCarteIngredientJouee info) {
+		
+		String designationJoueur1;
+		if(info.getNumeroJoueur() == 0) {
+			designationJoueur1 = "Vous jouez ";
+		} else {
+			designationJoueur1 = "Le joueur " + (info.getNumeroJoueur()+1) + " joue ";
+		}
+		
+		System.out.println("        --> " + designationJoueur1 + "la carte \"" + info.getCarteJouee().getNom() + "\"");
+	
+		
+		String designationJoueur2;
+		if(info.getNumeroJoueur() == 0) {
+			designationJoueur2 = "Vous avez ";
+		} else {
+			designationJoueur2 = "Le joueur " + (info.getNumeroJoueur()+1) + " a ";
+		}
+		if(info.getActionJouee() == Action.GEANT) {
+			System.out.println("            " + designationJoueur2 + "récupéré " + info.getForceReelle() + " graine(s).");
+		} else if(info.getActionJouee() == Action.ENGRAIS) {
+			System.out.println("            " + designationJoueur2 + "fait pousser " + info.getForceReelle() + " graine(s) en menhir(s).");
+		} else {
+			System.out.println("            " + designationJoueur2 + "volé " + info.getForceReelle() + " graine(s) au joueur " + (info.getJoueurCible()+1) + ".");
+		}
+	}
+	
+	public void notifierAgissementCarte(InfoCarteAlliesJouee info) {
+		String designationJoueur1;
+		if(info.getNumeroJoueur() == 0) {
+			designationJoueur1 = "Vous jouez ";
+		} else {
+			designationJoueur1 = "Le joueur " + (info.getNumeroJoueur()+1) + " joue ";
+		}
+		
+		System.out.println("        --> " + designationJoueur1 + "la carte \"" + info.getCarteJouee().getNom() + "\"");
+		
+		String designationJoueur2;
+		if(info.getNumeroJoueur() == 0) {
+			designationJoueur2 = "Vous avez ";
+		} else {
+			designationJoueur2 = "Le joueur " + (info.getNumeroJoueur()+1) + " a ";
+		}
+		if(info.getCarteJouee() instanceof ChiensDeGarde) {
+			System.out.println("            " + designationJoueur2 + "protégé " + info.getForceReelle() + " graine(s).");
+		} else if(info.getCarteJouee() instanceof TaupesGeantes) {
+			System.out.println("            " + designationJoueur2 + "détruit " + info.getForceReelle() + " menhir(s) du joueur " + (info.getJoueurCible()+1) + ".");
 		}
 	}
 }

--- a/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/Joueur.java
+++ b/JeuDuMenhir/src/fr/utt/girardguittard/levasseur/menhir/joueurs/Joueur.java
@@ -4,6 +4,8 @@ import fr.utt.girardguittard.levasseur.menhir.Manche;
 import fr.utt.girardguittard.levasseur.menhir.Saison;
 import fr.utt.girardguittard.levasseur.menhir.cartes.Action;
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteIngredient;
+import fr.utt.girardguittard.levasseur.menhir.cartes.InfoCarteAlliesJouee;
+import fr.utt.girardguittard.levasseur.menhir.cartes.InfoCarteIngredientJouee;
 import fr.utt.girardguittard.levasseur.menhir.cartes.CarteAllies;
 import fr.utt.girardguittard.levasseur.menhir.joueurs.MainJoueur;
 import fr.utt.girardguittard.levasseur.menhir.ui.InterfaceManager;
@@ -44,9 +46,10 @@ public abstract class Joueur {
 	 * Il s'agit de décider qu'elle action réaliser et de l'effectuer.
 	 * @param manche la manche en cours
 	 * @param tour le tour en cours
+	 * @return 
 	 * @throws CarteInvalideException 
 	 */
-	public void jouerTour(Manche manche, Saison tour) throws CarteInvalideException {
+	public InfoCarteIngredientJouee jouerTour(Manche manche, Saison tour) throws CarteInvalideException {
 		ChoixCarteIngredient choix = deciderChoixDuTour(manche, tour);
 		
 		//On vérifie bien que la carte est dans la main du joueur
@@ -56,6 +59,8 @@ public abstract class Joueur {
 		
 		int forceReelle = choix.getCarteChoisie().agir(manche, this.main, choix.getCible(), tour, choix.getActionChoisie());
 		this.getMain().retirerCarteIngredient(choix.getCarteChoisie());
+		
+		return new InfoCarteIngredientJouee(this.numero, tour, choix, forceReelle);
 	}
 	
 	/**
@@ -63,18 +68,24 @@ public abstract class Joueur {
 	 * @param manche la manche en cours
 	 * @param tour le tour en cours
 	 * @param joueurActuel le numéro du joueur dont c'est le tour actuellement
+	 * @return 
 	 */
-	public void jouerCartesAllies(Manche manche, Saison tour, int joueurActuel) {
+	public InfoCarteAlliesJouee jouerCartesAllies(Manche manche, Saison tour, int joueurActuel) {
 		if(this.getMain().getCarteAllies() != null)
 		{
 			ChoixCarteAllies choix = deciderCarteAllies(manche, tour, joueurActuel);
 			if(choix.isJoue())
 			{
-				int forceReelle = this.getMain().getCarteAllies().agir(manche, this.getMain(), choix.getCible(), tour);
+				CarteAllies carteAllies = this.getMain().getCarteAllies();
+				int forceReelle = carteAllies.agir(manche, this.getMain(), choix.getCible(), tour);
 				
-				this.getMain().retirerCarteAllies();	
+				this.getMain().retirerCarteAllies();
+				
+				return new InfoCarteAlliesJouee(this.numero, tour, choix, carteAllies, forceReelle);
 			}
 		}
+		
+		return new InfoCarteAlliesJouee(this.numero, tour, new ChoixCarteAllies(false, -1), null, 0);
 	}
 	
 	/**


### PR DESCRIPTION
Permet d'afficher à l'utilisateur quand une carte est jouée (cartes ingrédients et alliés).

Le jeu console a été mis à jour pour supporter cela. Il est maintenant autant fonctionnel que dans la version du livrable 2.
